### PR TITLE
remove need for wrapper script

### DIFF
--- a/man/socketmaster.1.ronn
+++ b/man/socketmaster.1.ronn
@@ -16,7 +16,11 @@ and can keep your file-descriptor indefinitely open.
 
   * `-command`=PATH:
     Defines the location of the program to execute and pass the file-descriptor
-    onto. If you need to add arguments to the program use a wrapper script.
+    onto. If you need to add arguments to the program, use -- before the command specific
+    arguments or use a wrapper script.
+
+    e.g.
+    socketmaster -command <command> -- -arg1 -arg2
   
   * `-listen`=URI:
     One of the following schemes are accepted: tcp, tcp4, tcp6 and unix.

--- a/man/socketmaster.1.ronn
+++ b/man/socketmaster.1.ronn
@@ -49,13 +49,13 @@ On SIGHUP:
 
  * socketmaster starts a new -command
  * waits for -start milliseconds
- * sends a SIGHUP to the other child processes
+ * sends a SIGTERM to the other child processes
 
 Your server is responsible for:
 
  * opening the socket passed on fd 3
  * not crashing
- * gracefully shutdown on SIGHUP (close the listener, wait for the child
+ * gracefully shutdown on SIGTERM (close the listener, wait for the child
    connections to close)
 
 ## ENVIRONMENT

--- a/process_group.go
+++ b/process_group.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"strconv"
 	"sync"
+	"flag"
 	"syscall"
 )
 
@@ -59,8 +60,9 @@ func (self *ProcessGroup) StartProcess() (process *os.Process, err error) {
 		}
 	}
 
-	log.Println("Starting", self.commandPath)
-	process, err = os.StartProcess(self.commandPath, []string{}, procAttr)
+	args := append([]string {self.commandPath},flag.Args()...)
+	log.Println("Starting", self.commandPath,args)
+	process, err = os.StartProcess(self.commandPath, args, procAttr)
 	if err != nil {
 		return
 	}

--- a/socketmaster.go
+++ b/socketmaster.go
@@ -32,7 +32,7 @@ func handleSignals(processGroup *ProcessGroup, c <-chan os.Signal, startTime int
 
 				// A possible improvement woud be to only swap the
 				// process if the new child is still alive.
-				processGroup.SignalAll(signal, process)
+				processGroup.SignalAll(syscall.SIGTERM, process)
 			}
 		default:
 			// Forward signal


### PR DESCRIPTION
Would like to be able to avoid the need for a wrapper script to pass arguments. -- is std. unix way to terminate arglist, using the same in this patch.