### PR TITLE
Improvement swap child if the new one is still alive

### DIFF
--- a/process_group.go
+++ b/process_group.go
@@ -131,6 +131,12 @@ func (self *processSet) Remove(process *os.Process) {
 	delete(self.set, process)
 }
 
+func (self *processSet) Len() int {
+	self.Lock()
+	defer self.Unlock()
+	return len(self.set)
+}
+
 func logOutput(input *os.File, pid int, wg sync.WaitGroup) {
 	var err error
 	var line string

--- a/socketmaster.go
+++ b/socketmaster.go
@@ -30,9 +30,11 @@ func handleSignals(processGroup *ProcessGroup, c <-chan os.Signal, startTime int
 					time.Sleep(time.Duration(startTime) * time.Millisecond)
 				}
 
-				// A possible improvement woud be to only swap the
-				// process if the new child is still alive.
-				processGroup.SignalAll(syscall.SIGTERM, process)
+				if processGroup.set.Len() > 1 {
+					processGroup.SignalAll(syscall.SIGTERM, process)
+				} else {
+					log.Println("Failed to kill old process, because there's no one left in the group")
+				}
 			}
 		default:
 			// Forward signal


### PR DESCRIPTION
```
// A possible improvement woud be to only swap the
// process if the new child is still alive.
```

According to that comment, we need to make sure that new process up and running before terminating old process. 