### PR TITLE
Call wg.Add(1) synchronously

### DIFF
--- a/process_group.go
+++ b/process_group.go
@@ -71,7 +71,7 @@ func (self *ProcessGroup) StartProcess() (process *os.Process, err error) {
 	self.set.Add(process)
 
 	// Prefix stdout and stderr lines with the [pid] and send it to the log
-	go logOutput(ioReader, process.Pid, self.wg)
+	logOutput(ioReader, process.Pid, self.wg)
 
 	// Handle the process death
 	go func() {
@@ -138,18 +138,22 @@ func (self *processSet) Len() int {
 }
 
 func logOutput(input *os.File, pid int, wg sync.WaitGroup) {
-	var err error
-	var line string
 	wg.Add(1)
 
-	reader := bufio.NewReader(input)
+	go func() {
+		defer wg.Done()
 
-	for err == nil {
-		line, err = reader.ReadString('\n')
-		if line != "" {
-			log.Printf("[%d] %s", pid, line)
+		var (
+			err    error
+			line   string
+			reader = bufio.NewReader(input)
+		)
+
+		for err == nil {
+			line, err = reader.ReadString('\n')
+			if line != "" {
+				log.Printf("[%d] %s", pid, line)
+			}
 		}
-	}
-
-	wg.Done()
+	}()
 }


### PR DESCRIPTION
Previously, `wg.Add(1)` was being called in a separate goroutine. On the main goroutine, `wg.Wait()` was being called. This causes a race when `Add()` and `Wait()` are called concurrently. This race is preempted by the `WaitGroup` code, which panics.

This race occurs very infrequently, and I haven't been able to consistently reproduce it. Here's a stacktrace from a time when this occurred in a development environment though

```
socketmaster[81741] 2019/10/01 12:55:11 Listening on tcp://127.0.0.1:5543
socketmaster[81741] 2019/10/01 12:55:11 Starting ./bin/server [./bin/server]
panic: sync: WaitGroup misuse: Add called concurrently with Wait
someapp   |
goroutine 19 [running]:
sync.(*WaitGroup).Add(0xc00001c354, 0x1)
    /usr/local/Cellar/go/1.12.9/libexec/src/sync/waitgroup.go:77 +0x117
main.logOutput(0xc000010030, 0x14227, 0x100000000, 0xc000000000)
    /Users/someuser/foo/bar/vendor/someapp/vendor/github.com/zimbatm/socketmaster/process_group.go:137 +0x73
created by main.(*ProcessGroup).StartProcess
    /Users/someuser/foo/bar/vendor/someapp/vendor/github.com/zimbatm/socketmaster/process_group.go:74 +0x54f
Exited
```

