### PR TITLE
Refactor the client to handle HTTP and grpc servers

### DIFF
--- a/slave/Example.md
+++ b/slave/Example.md
@@ -27,11 +27,10 @@ func main() {
 	flag.Parse()
 
 	server := &http.Server{
-		Addr:    addr,
 		Handler: new(SleepyHandler),
 	}
 
-	slave.Serve(server, 5 * time.Minute)
+	slave.ServeHTTP(server, addr, 5 * time.Minute)
 
 	log.Println("Bye bye")
 }

--- a/slave/Example.md
+++ b/slave/Example.md
@@ -30,7 +30,7 @@ func main() {
 		Handler: new(SleepyHandler),
 	}
 
-	slave.ServeHTTP(server, addr, 5 * time.Minute)
+	slave.ListenAndServeHTTP(server, addr, 5 * time.Minute)
 
 	log.Println("Bye bye")
 }

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -46,7 +46,7 @@ func (a *grpcAPP) ShutdownFunc(timeout time.Duration) func() {
 	}
 }
 
-func ServeHTTP(server *http.Server, address string, timeout time.Duration) error {
+func ListenAndServeHTTP(server *http.Server, address string, timeout time.Duration) error {
 	server.Addr = address
 
 	app := &httpAPP{server: server}
@@ -62,7 +62,7 @@ func ServeHTTP(server *http.Server, address string, timeout time.Duration) error
 	return app.server.Serve(l)
 }
 
-func ServeGRPC(server *grpc.Server, address string, timeout time.Duration) error {
+func ListenAndServeGRPC(server *grpc.Server, address string, timeout time.Duration) error {
 	app := &grpcAPP{server: server}
 
 	l, err := Listen(address)


### PR DESCRIPTION
Refactored and changed the signature to support http and grpc clients.

HTTP:
```
httpServer := http.Server{
  Handler: newServer(),
}

if err := slave.ServeHTTP(&httpServer, ":8080", time.Minute); err != nil {
     logger.Fatal(err.Error())
}
```

GRPC:
```
grpcServer := grpc.NewServer(...)

if err := slave.ServeGRPC(&grpcServer, ":8080", time.Minute); err != nil {
     logger.Fatal(err.Error())
}
```
```