### PR TITLE
Fix logOutput race

### DIFF
--- a/process_group.go
+++ b/process_group.go
@@ -71,7 +71,7 @@ func (self *ProcessGroup) StartProcess() (process *os.Process, err error) {
 	self.set.Add(process)
 
 	// Prefix stdout and stderr lines with the [pid] and send it to the log
-	logOutput(ioReader, process.Pid, self.wg)
+	logOutput(ioReader, process.Pid, &self.wg)
 
 	// Handle the process death
 	go func() {
@@ -137,7 +137,7 @@ func (self *processSet) Len() int {
 	return len(self.set)
 }
 
-func logOutput(input *os.File, pid int, wg sync.WaitGroup) {
+func logOutput(input *os.File, pid int, wg *sync.WaitGroup) {
 	wg.Add(1)
 
 	go func() {

--- a/process_group_test.go
+++ b/process_group_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_logOutput(t *testing.T) {
+	t.Run("wg waits for logOutput", func(t *testing.T) {
+		var stdErr bytes.Buffer
+		log.SetOutput(&stdErr)
+		log.SetFlags(0)
+		ioReader, ioWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		inputs := []string{"foo", "bar"}
+		want := "[1] foo\n[1] bar\n"
+		var waitForWrite sync.WaitGroup
+		waitForWrite.Add(1)
+
+		go func(wg *sync.WaitGroup) {
+			for _, input := range inputs {
+				_, err = ioWriter.WriteString(input + "\n")
+				if err != nil {
+					t.Fatal("unexpected error", err)
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+			err = ioWriter.Close()
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			wg.Done()
+		}(&waitForWrite)
+
+		var wg sync.WaitGroup
+		logOutput(ioReader, 1, wg)
+
+		wg.Wait()
+		got := stdErr.String()
+		if got != want {
+			t.Fatalf("unexpected output:\n\twanted: %q\n\tgot: %q", want, got)
+		}
+		waitForWrite.Wait()
+	})
+}

--- a/process_group_test.go
+++ b/process_group_test.go
@@ -39,7 +39,7 @@ func Test_logOutput(t *testing.T) {
 		}(&waitForWrite)
 
 		var wg sync.WaitGroup
-		logOutput(ioReader, 1, wg)
+		logOutput(ioReader, 1, &wg)
 
 		wg.Wait()
 		got := stdErr.String()

--- a/process_group_test.go
+++ b/process_group_test.go
@@ -24,18 +24,19 @@ func Test_logOutput(t *testing.T) {
 		waitForWrite.Add(1)
 
 		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
 			for _, input := range inputs {
 				_, err = ioWriter.WriteString(input + "\n")
 				if err != nil {
-					t.Fatal("unexpected error", err)
+					t.Error("unexpected error", err)
+					return
 				}
 				time.Sleep(5 * time.Millisecond)
 			}
 			err = ioWriter.Close()
 			if err != nil {
-				t.Fatal("unexpected error", err)
+				t.Error("unexpected error", err)
 			}
-			wg.Done()
 		}(&waitForWrite)
 
 		var wg sync.WaitGroup


### PR DESCRIPTION
`logOutput()` accepts a `sync.WaitGroup` argument and attempts to add itself to the waitgroup. This is ineffectual because it is receiving `sync.WaitGroup` by value instead of a pointer.  The result is that socketmaster can terminate before it is done writing output.

This PR corrects that by changing logOutput's WaitGroup argument to a pointer.

I included a test demonstrating the issue. I see there are no other tests in this repo. I have no attachment to this test, so feel free to delete it before merging.
